### PR TITLE
Remove references to JCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Koncorda
 
-![Bintray](https://img.shields.io/bintray/v/yttrian/koncorda/koncorda?label=koncorda)
-![Bintray (latest)](https://img.shields.io/bintray/dt/yttrian/koncorda/koncorda)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/yttrian/koncorda)
+![GitHub Sponsors](https://img.shields.io/github/sponsors/yttrian)
 
 A small DSL for quickly creating a command bot with [JDA](https://github.com/DV8FromTheWorld/JDA).
 Inspired by the simplicity [Ktor](https://github.com/ktorio/ktor).
 
 # Installation
 
-Add the JCenter repository, the latest Koncorda release, JDA, and an SLF4J implementation to your `build.gradle.kts`.
+Add the Maven Central, Jitpack and dv8tion repositories, the latest Koncorda release, JDA, and an SLF4J implementation
+to your `build.gradle.kts`.
 
 While Koncorda is intended to be somewhat opinionated, you are free to chose your SLF4J implementation.
 Logback is recommended for the sole reason that it's what the Ktor project generator suggests.
@@ -18,15 +19,18 @@ without needing Koncorda to be updated as well. As well as being able to chose t
 
 ```kotlin
 repositories {
-    jcenter()
+    mavenCentral()
+    maven("https://m2.dv8tion.net/releases")
+    maven("https://jitpack.io")
 }
-
+```
+```kotlin
 dependencies {
     implementation("ch.qos.logback:logback-classic:1.2.3")
-    implementation("net.dv8tion:JDA:4.2.0_227") {
+    implementation("net.dv8tion:JDA:4.2.1_253") {
         exclude(module = "opus-java") // optional, for if you don't plan to use voice chat
     }
-    implementation("org.yttr:koncorda:0.2.3")
+    implementation("com.github.yttrian:koncorda:0.3.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "org.yttr"
-version = "0.2.3"
+version = "0.3.0"
 
 plugins {
     id("tanvd.kosogor") version "1.0.10" apply true
-    id("io.gitlab.arturbosch.detekt") version "1.15.0" apply true
+    id("io.gitlab.arturbosch.detekt") version "1.17.0" apply true
     kotlin("jvm") version "1.4.30" apply false
 }
 
@@ -17,7 +17,8 @@ subprojects {
     }
 
     repositories {
-        jcenter()
+        mavenCentral()
+        maven("https://m2.dv8tion.net/releases")
     }
 
     tasks.withType<KotlinCompile>() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 kotlin.code.style=official
-jdaVersion=4.2.0_227
+jdaVersion=4.2.1_253
 hoconVersion=1.4.1
 coroutinesVersion=1.4.2
 logbackVersion=1.2.3


### PR DESCRIPTION
JCenter has been sunset as of May 1st.

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/